### PR TITLE
Support other s3 compatible providers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ configurations {
 project.ext {
 	pluginId = "s3"
 	pluginName = "Amazon S3"
-	pluginVersion = "0.3.0-alpha"	
+	pluginVersion = "0.3.1-alpha"	
 	pluginDebianVersion = "1"	
 	pluginDate = new Date()
 	pluginAppMinVersion = "0.3.0-alpha"

--- a/src/main/java/org/syncany/plugins/s3/S3TransferManager.java
+++ b/src/main/java/org/syncany/plugins/s3/S3TransferManager.java
@@ -128,11 +128,11 @@ public class S3TransferManager extends AbstractTransferManager {
 
 		if (bucket == null) {
 			if (getSettings().getEndpoint() != null) {
-				logger.log(Level.INFO, "Using non standard endpoint, ignoring region.");
+				logger.log(Level.INFO, "Using non-standard endpoint, ignoring region.");
 				bucket = new S3Bucket(getSettings().getBucket());
 			}
 			else {
-				logger.log(Level.INFO, "Using amazon s3 endpoint, setting location.");
+				logger.log(Level.INFO, "Using Amazon S3 endpoint, setting location.");
 				bucket = new S3Bucket(getSettings().getBucket(), getSettings().getLocation());
 			}
 		}

--- a/src/main/java/org/syncany/plugins/s3/S3TransferSettings.java
+++ b/src/main/java/org/syncany/plugins/s3/S3TransferSettings.java
@@ -40,11 +40,11 @@ public class S3TransferSettings extends TransferSettings {
 	private String bucket;
 
 	@Element(name = "endpoint", required = false)
-	@Setup(order = 4, description = "If you are not using amazon s3, enter the location of your endpoint")
+	@Setup(order = 4, description = "Endpoint (non-standard S3-compatible backends only)")
 	private String endpoint;
 
 	@Element(name = "location", required = true)
-	@Setup(order = 5, description = "Amazon s3 region (ignored if you are using an endpoint other than amazon s3)")
+	@Setup(order = 5, description = "Amazon S3 Region/Location (ignored for if endpoint is set)")
 	private String location = S3Bucket.LOCATION_US_WEST; // cf. http://jets3t.s3.amazonaws.com/api/constant-values.html
 
 	private ProviderCredentials credentials;


### PR DESCRIPTION
As requested, this fixes syncany/syncany#301 by extending the s3 plugin
to support providers other than amazon s3. Please note that the region
property is ignored in such cases.
